### PR TITLE
Fixed a variety of issues I had.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,6 @@ Wiggle 2 is a ground up rewrite of the [wiggle bones add-on](https://github.com/
 ### New physics logic.
 - Wiggling now behaves more realistically, especially when simulating simple ropes or chains.
 
-### Pinning.
-- Using a damped track constraint on a wiggling bone pins it to its target, with other bones responding accordingly.
-!["Pinning"](/images/pinning.png?raw=true "Pinning")
-
 ### Collision support.
 - Bones can collide with a specified mesh or collection, and respond with friction, bouncing, or even stickiness.
 !["Collision"](/images/collision.png?raw=true "Collision")

--- a/wiggle_2.py
+++ b/wiggle_2.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Wiggle 2",
     "author": "Steve Miller",
-    "version": (2, 2, 4),
+    "version": (2, 2, 5),
     "blender": (3, 00, 0),
     "location": "3d Viewport > Animation Panel",
     "description": "Simulate spring-like physics on Bone transforms",
@@ -488,7 +488,6 @@ def wiggle_pre(scene):
             b.rotation_quaternion = Quaternion((1,0,0,0))
             b.rotation_euler = Vector((0,0,0))
             b.scale = Vector((1,1,1))
-    bpy.context.view_layer.update()
 
 @persistent                
 def wiggle_post(scene,dg):

--- a/wiggle_2.py
+++ b/wiggle_2.py
@@ -496,9 +496,10 @@ def wiggle_post(scene,dg):
     wiggle_list = wiggle.list
     wiggle_iterations = wiggle.iterations
 
+    objects = scene.objects
     for _ in range(accumulatedFrames):
         for wo in wiggle_list:
-            ob = scene.objects[wo.name]
+            ob = objects[wo.name]
 
             if getattr(ob, 'wiggle_mute', False) or getattr(ob, 'wiggle_freeze', False):
                 continue
@@ -570,43 +571,44 @@ class WiggleCopy(bpy.types.Operator):
     
     def execute(self,context):
         b = context.active_pose_bone
-        b.wiggle_mute = b.wiggle_mute
-        b.wiggle_head = b.wiggle_head
-        b.wiggle_tail = b.wiggle_tail
-        b.wiggle_head_mute = b.wiggle_head_mute
-        b.wiggle_tail_mute = b.wiggle_tail_mute
-        
-        b.wiggle_mass = b.wiggle_mass
-        b.wiggle_stiff = b.wiggle_stiff
-        b.wiggle_stretch = b.wiggle_stretch
-        b.wiggle_damp = b.wiggle_damp
-        b.wiggle_gravity = b.wiggle_gravity
-        b.wiggle_wind_ob = b.wiggle_wind_ob
-        b.wiggle_wind = b.wiggle_wind
-        b.wiggle_collider_type = b.wiggle_collider_type
-        b.wiggle_collider = b.wiggle_collider
-        b.wiggle_collider_collection = b.wiggle_collider_collection
-        b.wiggle_radius = b.wiggle_radius
-        b.wiggle_friction = b.wiggle_friction
-        b.wiggle_bounce = b.wiggle_bounce
-        b.wiggle_sticky = b.wiggle_sticky
-        b.wiggle_chain = b.wiggle_chain
-        
-        b.wiggle_mass_head = b.wiggle_mass_head
-        b.wiggle_stiff_head = b.wiggle_stiff_head
-        b.wiggle_stretch_head = b.wiggle_stretch_head
-        b.wiggle_damp_head = b.wiggle_damp_head
-        b.wiggle_gravity_head = b.wiggle_gravity_head
-        b.wiggle_wind_ob_head = b.wiggle_wind_ob_head
-        b.wiggle_wind_head = b.wiggle_wind_head
-        b.wiggle_collider_type_head = b.wiggle_collider_type_head
-        b.wiggle_collider_head = b.wiggle_collider_head
-        b.wiggle_collider_collection_head = b.wiggle_collider_collection_head
-        b.wiggle_radius_head = b.wiggle_radius_head
-        b.wiggle_friction_head = b.wiggle_friction_head
-        b.wiggle_bounce_head = b.wiggle_bounce_head
-        b.wiggle_sticky_head = b.wiggle_sticky_head
-        b.wiggle_chain_head = b.wiggle_chain_head
+        for ob in context.selected_pose_bones:
+            ob.wiggle_mute = b.wiggle_mute
+            ob.wiggle_head = b.wiggle_head
+            ob.wiggle_tail = b.wiggle_tail
+            ob.wiggle_head_mute = b.wiggle_head_mute
+            ob.wiggle_tail_mute = b.wiggle_tail_mute
+            
+            ob.wiggle_mass = b.wiggle_mass
+            ob.wiggle_stiff = b.wiggle_stiff
+            ob.wiggle_stretch = b.wiggle_stretch
+            ob.wiggle_damp = b.wiggle_damp
+            ob.wiggle_gravity = b.wiggle_gravity
+            ob.wiggle_wind_ob = b.wiggle_wind_ob
+            ob.wiggle_wind = b.wiggle_wind
+            ob.wiggle_collider_type = b.wiggle_collider_type
+            ob.wiggle_collider = b.wiggle_collider
+            ob.wiggle_collider_collection = b.wiggle_collider_collection
+            ob.wiggle_radius = b.wiggle_radius
+            ob.wiggle_friction = b.wiggle_friction
+            ob.wiggle_bounce = b.wiggle_bounce
+            ob.wiggle_sticky = b.wiggle_sticky
+            ob.wiggle_chain = b.wiggle_chain
+            
+            ob.wiggle_mass_head = b.wiggle_mass_head
+            ob.wiggle_stiff_head = b.wiggle_stiff_head
+            ob.wiggle_stretch_head = b.wiggle_stretch_head
+            ob.wiggle_damp_head = b.wiggle_damp_head
+            ob.wiggle_gravity_head = b.wiggle_gravity_head
+            ob.wiggle_wind_ob_head = b.wiggle_wind_ob_head
+            ob.wiggle_wind_head = b.wiggle_wind_head
+            ob.wiggle_collider_type_head = b.wiggle_collider_type_head
+            ob.wiggle_collider_head = b.wiggle_collider_head
+            ob.wiggle_collider_collection_head = b.wiggle_collider_collection_head
+            ob.wiggle_radius_head = b.wiggle_radius_head
+            ob.wiggle_friction_head = b.wiggle_friction_head
+            ob.wiggle_bounce_head = b.wiggle_bounce_head
+            ob.wiggle_sticky_head = b.wiggle_sticky_head
+            ob.wiggle_chain_head = b.wiggle_chain_head
         return {'FINISHED'}
 
 class WiggleReset(bpy.types.Operator):

--- a/wiggle_2.py
+++ b/wiggle_2.py
@@ -644,7 +644,7 @@ class WiggleBake(bpy.types.Operator):
                 frame = context.scene.frame_end - (preroll%duration)
                 context.scene.frame_set(frame)
             else:
-                context.scene.frame_set(context.scene.frame_start)
+                context.scene.frame_set(context.scene.frame_start-preroll)
             context.scene.wiggle.is_preroll = True
             preroll -= 1
         #bake

--- a/wiggle_2.py
+++ b/wiggle_2.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Wiggle 2",
     "author": "Steve Miller",
-    "version": (2, 2, 5),
+    "version": (3, 0, 0),
     "blender": (3, 00, 0),
     "location": "3d Viewport > Animation Panel",
     "description": "Simulate spring-like physics on Bone transforms",


### PR DESCRIPTION
I made some changes for my personal use for Blender LTS 4.2.10, detailed below. They're fairly intense and I don't expect them to be merged. Felt like sharing them after I saw how many of my animator friends use this addon.

- ef5b7429f1fc1591c0301d9c03956e7446baf23e Optimization

I was annoyed with how even with wiggle simply enabled (with no bones wiggling), performance would tank.

Using cProfile, I timed functions and found the `wiggle_pre` function was taking the majority of the time to run. Found at the bottom of the function a lone `bpy.context.view_layer.update()` was causing a complete re-computation of the scene, this included all _modifiers_ and constraints! This would compound heavily with heavier scenes.

I also don't believe calling that function is necessary as I believe the full dependency graph is evaluated right after the frame_changed_post handler anyway in order to resolve constraints! Removing it has significantly increased viewport performance, as well as baking performance!

- 83d641750b3b367cbbb5cb5dbd836c2a41ea5f84 Now allows up to 4 dropped frames during playback.

In a low-performance scene, it's sometimes useful to switch the animation mode to "Frame Dropping". Wiggle bones doesn't allow for this as it is very timestep dependent (as most physics simulations are).

I've rearchitectured slightly to only ever allow timesteps in chunks of `1/scene.framerate`, and allowing up to 4 skipped frames. This has made Frame Dropping a viable way to preview the wiggle settings. It has the added benefit of being more consistent of a simulation.

I also deleted comments that seemed irrelevant or old around areas I was refactoring, this caused git to generate some really awful diffs. Makes it hard to read. Sorry!

- 9d30307c4b26769c78f93895f9f992d9b6009ca7 Constraints no longer make wiggles unusable

I often use AutoRigPro rigs, which use a technique involving rotation constraints to make it easy to pose hair, tails, and ears. Wiggle has some special handling code for constraints that I'm guessing was put there for the pinning feature. This causes the simulation to explode immediately.

Testing the pinning feature I found it doesn't work in this version of blender.

Therefore I removed all special handling of constraints. Which was easier than trying to figure out what changed that broke pinning.

So now instead of exploding instantly, bones with modifiers have a variety of behaviors that a user can more easily track down and adjust.

I also removed the pinning feature description in the README with e11fab55ea70948c672bce79c5cebf31f34b60b2

I personally never needed this feature. I've also removed all pinning code as it didn't appear to be functional.

- 23b2e67151aa98d07ae57a7f9457dd0aaf1d4af9 Fixed preroll setting only working on looped animations.

Simple fix, calls to `scene.frame_set()` in this version of blender are ignored if the frame is already the same. Added in the preroll offset and tested that it works.

- 729fdb9e185d98d30600c6f6574e088bfa9dd6d3 semantic version bump

As I have removed a feature, and changed how it interacts with constraints, I have taken the liberty of bumping the version 3.0.0. I didn't really plan on you accepting a pull request, but just in-case I tried to make it a one-click effort.

I plan to use my fork for a while and submit maintenance patches if I find further issues. I'll update my pull request if that happens. Thank you for such a wonderful addon!